### PR TITLE
Docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,5 +52,6 @@ aliases.json
 dev.env
 sta.env
 pro.env
+docker.env
 
 celerybeat-schedule.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,4 @@ FROM python:2.7
 WORKDIR /tmp
 ADD requirements.txt ./
 RUN pip install --src /pylibs -r requirements.txt
+RUN openssl req -new -newkey rsa:4096 -days 365 -nodes -x509 -subj "/C=US/ST=State/L=City/O=Section/CN=domainname" -keyout site.key -out site.crt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:2.7
+WORKDIR /tmp
+ADD requirements.txt ./
+RUN pip install --src /pylibs -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ then
     python manage.py runserver
 
 
+### Running on docker
+
+Install docker and docker-compose, copy `docker.env.example` as `docker.env` and update the settings as described in that file. Then run:
+
+    docker-compose up
+
+This will start up three docker containers, one for MongoDB, one for Redis and one for the web app. Once started, the application should be available at the location specified in `SERVICE_URL`. 
+
+
 ### Running on heroku
 
 You will need to install the [heroku toolbelt](https://toolbelt.heroku.com/).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 web:
     build: .
     working_dir: /code     
-    command: gunicorn --bind="0.0.0.0:5067" --certfile=/tmp/site.crt --keyfile=/tmp/site.key --ssl-version=2 --error-logfile=- --access-logfile=- main:main_app
+    command: gunicorn --bind="0.0.0.0:5067" --certfile=/tmp/site.crt --keyfile=/tmp/site.key --ssl-version=2 --error-logfile=- --access-logfile=- --reload main:main_app
     ports:
         - "5067:5067"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 web:
     build: .
     working_dir: /code     
-    command: python manage.py runserver --host 0.0.0.0 --port 5067
+    command: gunicorn --bind="0.0.0.0:5067" --certfile=/tmp/site.crt --keyfile=/tmp/site.key --ssl-version=2 --error-logfile=- --access-logfile=- main:main_app
     ports:
         - "5067:5067"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+web:
+    build: .
+    working_dir: /code     
+    command: python manage.py runserver --host 0.0.0.0 --port 5067
+    ports:
+        - "5067:5067"
+    volumes:
+        - .:/code
+    links:
+        - redis
+        - mongodb
+    env_file:
+      - .env
+
+redis:
+    image: redis:2.8.19
+
+mongodb:
+    image: mongo:2.6.7
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,12 @@ web:
         - redis
         - mongodb
     env_file:
-      - .env
+      - docker.env
+    environment:
+      - MONGO_HOST=mongodb:27017
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
+      - PYTHONPATH=/pylib
 
 redis:
     image: redis:2.8.19

--- a/docker.env.example
+++ b/docker.env.example
@@ -1,0 +1,14 @@
+# If you want to use a Docker development environment, create a copy of this file
+# named docker.env and update the settings as described in the comments below.
+
+# If you are not running Docker locally on Linux, change the IP address in the following two lines
+# to the IP address of the Docker host (e.g. the result of `boot2docker ip` or `docker-machine ip`)
+SERVICE_URL=https://127.0.0.1:5067
+API_ROOT=https://127.0.0.1:5067/ss
+DEBUG=1
+SECRET_KEY=This is not a very secret secret
+CONTACT_EMAIL=Change to your email_address
+# Set the following two lines to the credentials for a project you have set up in the Google Developer Console
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+

--- a/main/__init__.py
+++ b/main/__init__.py
@@ -1,4 +1,15 @@
 # -*- coding: utf-8 -*-
 
+import settings, wait, log
+
+wait_fors = (
+    settings.MONGO_HOST.split(':'),
+    (settings.REDIS_HOST, settings.REDIS_PORT)
+)
+for (host, port) in wait_fors:
+    log.info("Waiting for {0}:{1}".format(host, port))
+    if not wait.tcp.open(int(port), host, timeout=300):
+        raise EnvironmentError("Timeout waiting for {0}:{1}".format(host, port))
+
 from app import create_app
 main_app = app.create_app()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pymongo==2.7.1
 shortuuid==0.4.2
 paste
 gunicorn
+wait==0.0.3
 -e git+https://github.com/colevscode/quickdata.git#egg=quickdata
 -e git+https://github.com/colevscode/quickkvs.git#egg=quickkvs
 -e git+https://github.com/colevscode/gspread.git#egg=gspread


### PR DESCRIPTION
This adds support for a docker based development environment.

After you've added your config to `docker.env`, `docker-compose up` should start up MongoDB and Redis and get the gridspree app running under HTTPS with a self-signed cert and code changes causing an automatic app reload. The first run will take a while since it will have to fetch the redis and mongo images and build the python env for gridspree. After that it should be fairly quick.

I've only tested this on Ubuntu. I'd be interested on feedback running on non-Linux platforms. It should work fine but you will need to use a different IP in `docker.env` as the docker daemon will be running inside a VM on those platforms.

I had to add some code to `main/__init__.py` to get the app to wait unitl MongoDB and Redis are ready since the app fails with a fatal error if it gets further than this and can't connect to MongoDB. I don't think this should cause any problems when running in other environments.
